### PR TITLE
RouterState: fix still alive thread

### DIFF
--- a/igmp/igmp2/RouterState.py
+++ b/igmp/igmp2/RouterState.py
@@ -173,3 +173,5 @@ class RouterState(object):
         """
         for group in self.group_state.values():
             group.remove()
+        self.clear_general_query_timer()
+        self.clear_other_querier_present_timer()


### PR DESCRIPTION
The sample of code :

```
from igmp import InterfaceIGMP
from time import sleep

intf = InterfaceIGMP(interface_name="eth0")

intf.enable()
print('%s %s' % (intf.interface_name, intf.is_enabled()))

sleep(10)

intf.remove()
print('%s %s' % (intf.interface_name, intf.is_enabled()))
```

never returns because of a thread not being killed.
This commit fix it.